### PR TITLE
Update event handler name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
   config: configSchema,
 
-  postBuild: async ({
+  onPostBuild: async ({
     constants: { BUILD_DIR },
     pluginConfig: { entryPoints, ...subfontConfig }
   }) => {


### PR DESCRIPTION
Hi there,

Thanks a lot for working on this Netlify Build plugin!

As the Netlify Build Beta is moving forward, we are making some changes to the shape of the plugin, hoping to make it clearer to plugin authors. To that end, methods names now need to be prefixed with `on`. For example `build()` is now called `onBuild()`.
This PR implements this new name.

Please note that we will release those new method names on Monday both locally (Netlify CLI) and in the CI, so this PR should not be merged until then. I just thought I would give you some heads up!

Thanks again!