### PR TITLE
Remove return value from `onPostBuild`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,5 @@ module.exports = {
     );
 
     await headerPromise;
-
-    return result;
   },
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ module.exports = {
       immutableHeaders
     );
 
-    const result = await subfont(
+    const resultPromise = subfont(
       {
         ...subfontConfig,
         inputFiles: resolvedEntryPoints,
@@ -42,6 +42,6 @@ module.exports = {
       console
     );
 
-    await headerPromise;
+    await Promise.all([headerPromise, resultPromise]);
   },
 };


### PR DESCRIPTION
Plugin event handlers do not currently return values, but might in the future. Not returning anything ensures future changes won't break this plugin.