### PR TITLE
Rename `BUILD_DIR` to `PUBLISH_DIR`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const immutableHeaders = `
 
 module.exports = {
   onPostBuild: async ({
-    constants: { BUILD_DIR },
+    constants: { PUBLISH_DIR },
     inputs: { entryPoints, ...subfontConfig },
   }) => {
     console.log(
@@ -23,11 +23,11 @@ module.exports = {
     );
 
     const resolvedEntryPoints = globby
-      .sync(entryPoints, { cwd: BUILD_DIR })
-      .map((path) => resolve(BUILD_DIR, path));
+      .sync(entryPoints, { cwd: PUBLISH_DIR })
+      .map((path) => resolve(PUBLISH_DIR, path));
 
     const headerPromise = appendFile(
-      resolve(BUILD_DIR, '_headers'),
+      resolve(PUBLISH_DIR, '_headers'),
       immutableHeaders
     );
 
@@ -35,7 +35,7 @@ module.exports = {
       {
         ...subfontConfig,
         inputFiles: resolvedEntryPoints,
-        root: BUILD_DIR,
+        root: PUBLISH_DIR,
         canonicalRoot,
         inPlace: true,
       },


### PR DESCRIPTION
The `BUILD_DIR` constant has been renamed to `PUBLISH_DIR`.