### PR TITLE
Improve error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,9 @@ module.exports = {
   onPostBuild: async ({
     constants: { BUILD_DIR },
     inputs: { entryPoints, ...subfontConfig },
+    utils: {
+      build: { failBuild },
+    },
   }) => {
     console.log(
       `Running subfont version ${require('subfont/package.json').version}`
@@ -31,19 +34,21 @@ module.exports = {
       immutableHeaders
     );
 
-    const result = await subfont(
-      {
-        ...subfontConfig,
-        inputFiles: resolvedEntryPoints,
-        root: BUILD_DIR,
-        canonicalRoot,
-        inPlace: true,
-      },
-      console
-    );
+    try {
+      await subfont(
+        {
+          ...subfontConfig,
+          inputFiles: resolvedEntryPoints,
+          root: BUILD_DIR,
+          canonicalRoot,
+          inPlace: true,
+        },
+        console
+      );
+    } catch (error) {
+      failBuild('Subfont failed', { error });
+    }
 
     await headerPromise;
-
-    return result;
   },
 };


### PR DESCRIPTION
Subfont sometimes throws errors. For example, a build had the following:

```
Error Multiple @font-face with the same font-family/font-style/font-weight (maybe with different unicode-range?) is not supported yet: Roboto Slab/normal/300 
    /opt/build/repo/node_modules/subfont/lib/subsetFonts.js:678:19 subsetFonts
```

The `utils.build.failBuild()` function can be used to report those errors as user errors (as opposed to bugs within the plugin).