### PR TITLE
Use `NETLIFY_BUILD_VERSION` constant

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const immutableHeaders = `
 
 module.exports = {
   onPostBuild: async ({
-    constants: { PUBLISH_DIR },
+    constants: { PUBLISH_DIR, NETLIFY_BUILD_VERSION },
     inputs: { entryPoints, ...subfontConfig },
     utils: {
       build: { failPlugin },
@@ -35,7 +35,7 @@ module.exports = {
     );
 
     logger.debug('verions', {
-      'netlify-build': require('@netlify/build/package.json').version,
+      'netlify-build': NETLIFY_BUILD_VERSION,
       'netlify-plugin-subfont': require('../package.json').version,
       subfont: require('subfont/package.json').version,
       assetgraph: require('assetgraph/package.json').version,


### PR DESCRIPTION
This plugin tries to find out Netlify Build's version by using `require('@netlify/build')`. However this crashes in production with `Cannot find module '@netlify/build/package.json'`.

The reason this does not work is outlined in https://github.com/netlify/build/issues/1363.

I just added support for a new constant `NETLIFY_BUILD_VERSION` (https://github.com/netlify/build/pull/1364), which is a string with the `major.minor.patch` version of `@netlify/build`. 

At the moment, this constant is `undefined`, but this should become available within 24 hours. Also, having it `undefined` is probably better than the current behavior (the build crashes).